### PR TITLE
Remove deregistration of `"ToolkitAM1BCC"` parameter handler

### DIFF
--- a/src/pontibus/utils/system_creation.py
+++ b/src/pontibus/utils/system_creation.py
@@ -255,10 +255,6 @@ def _get_force_field(ffsettings: InterchangeFFSettings) -> ForceField:
     # forcefields is a list so we unpack it
     force_field = ForceField(*ffsettings.forcefields)
 
-    # Cautiously deregister the AM1BCC handler, we shouldn't need it.
-    # See: https://github.com/openforcefield/openff-interchange/issues/1048
-    force_field.deregister_parameter_handler("ToolkitAM1BCC")
-
     # We also set nonbonded cutoffs whilst we are here
     # TODO: double check what this means for nocutoff simulations
     force_field["Electrostatics"].cutoff = ffsettings.nonbonded_cutoff


### PR DESCRIPTION
As discussed in the OMSF free energy meeting yesterday, force fields that lack a `"ToolkitAM1BCC"` parameter handler currently fail to generate an alchemical network because the parameter handler is deregistered without first checking if it exists. Currently this can be worked around by specifying user charges and adding a "dummy" `"ToolkitAM1BCC"` tag to the force field, but @IAlibay mentioned that this deregistration should no longer be necessary, so this PR removes it.