### PR TITLE
Test against updated Packmol defaults

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,12 +3,12 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - gufe >=1.6
+  - gufe =1.6
   - openff-toolkit >0.16.0
   - openff-interchange >=0.4.8
   - openff-nagl-base >=0.3.3
   # OpenFE stack deps
-  - openfe >=1.6
+  - openfe
   - duecredit<0.10
   - kartograf>=1.0.0
   - konnektor
@@ -18,7 +18,7 @@ dependencies:
   - rdkit
   - packaging
   - pip
-  - pydantic >=2.0
+  - pydantic
   - pyyaml
   - coverage
   - cinnabar ~=0.5.0


### PR DESCRIPTION
(I tried to keep the unrelated changes minimal but enough to get tests passing here)

PR and documented behavior change(s) here: https://github.com/openforcefield/openff-interchange/pull/1332

Expected changes in Interchange 0.5.0 should not affect SFEs here:
* Packmol 20.15.0+ is required to use PBCs and an older version is bundled in AmberTools with no workaround available[^1] or upcoming
* Pontibus **does not** use the `target_density` argument which is undergoing a minor behavior change
* The behavior change with how the `box_vectors` argument is handled should not affect packing

If 0.5.0 does cause any issues, downpinning to 0.4.x or vendoring more code are each viable options.

Note also that these changes are only in the private API.


[^1]: I'm assuming here that AmberTools is a required dependency here