### PR TITLE
Make OpenFF responsible for issue triage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 * @j-wags
-* @atravitz 
-* @IAlibay 
+* @atravitz
+* @IAlibay


### PR DESCRIPTION
Per our discussion earlier today, this PR adds me to `.github/CODEOWNERS`, so I get emails when CI fails, and then I can triage who does fixes. 

I propose approving and merging this with failing CI, since this change doesn't affect any code files. 