### PR TITLE
Remove rdkit version pin from mypy workflow

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -30,7 +30,6 @@ jobs:
           cache-downloads: true
           create-args: >-
             python=3.11
-            rdkit=2023.09.5
           init-shell: bash
 
       - name: "Install steps"


### PR DESCRIPTION
Looks like it's mostly working upstream with openfe, so the pin may no longer be necessary.