### PR TITLE
pin openfe to 1.8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - openff-interchange >=0.4.8
   - openff-nagl-base >=0.3.3
   # OpenFE stack deps
-  - openfe >=1.8
+  - openfe == 1.8
   - duecredit<0.10
   - kartograf>=1.0.0
   - konnektor

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - openff-interchange >=0.4.8
   - openff-nagl-base >=0.3.3
   # OpenFE stack deps
-  - openfe == 1.8
+  - openfe ~= 1.8.0
   - duecredit<0.10
   - kartograf>=1.0.0
   - konnektor


### PR DESCRIPTION
Until we address the protocol updates, let's pin the main CI to `openfe v1.8`, to keep the CI green and catch any new breaking changes.

Then the additions in https://github.com/OpenFreeEnergy/pontibus/pull/178 will pass once we've made the protocol updates.


