### PR TITLE
Pin environment to numpy < 2.4

### DIFF
--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 dependencies:
 - autodoc-pydantic>=2.0
-- openfe>=1.7.0
+- openfe~=1.8.0
 - packaging
 - plugcli
 - python=3.11

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - kartograf>=1.0.0
   - konnektor
   - lomap2>=3.0.0
-  - numpy
+  - numpy <2.4 # unpin once #184 is fixed
   - networkx
   - rdkit
   - packaging


### PR DESCRIPTION
Unpin numpy version to allow updates after fixing issue #184.