### PR TITLE
bumping up AWS instance type for long cpu tests

### DIFF
--- a/.github/workflows/cpu-vslow-tests.yaml
+++ b/.github/workflows/cpu-vslow-tests.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: omsf/start-aws-gha-runner@v1.0.0
         with:
           aws_image_id: ami-0b7f661c228e6a4bb
-          aws_instance_type: c7i.xlarge
+          aws_instance_type: c8i.2xlarge
           aws_home_dir: /home/ubuntu
           aws_root_device_size: 125
         env:


### PR DESCRIPTION
I'm bumping up the AWS instance from c7i.xlarge to c8i.2xlarge. I noticed in the latest runs that runs were far too slow, so I'm going to try this and see if it helps.

P.S. I'm going to self-merge this so that we can carry on with testing long cpu tests, but we can review the image type afterwards.