### PR TITLE
Only run bleeding edge CI on commits to main and weekly

### DIFF
--- a/.github/workflows/ci-dev-main.yaml
+++ b/.github/workflows/ci-dev-main.yaml
@@ -1,14 +1,11 @@
 name: "CI - main branch of deps"
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
   schedule:
-    # At 07:00 UTC on Monday and Thursday
-    - cron: "0 7 * * *"
+    # At 07:00 UTC on Monday (weekly)
+    - cron: "0 7 * * 1"
   workflow_dispatch:
 
 


### PR DESCRIPTION
- [x] Fix #192